### PR TITLE
Adjustments to allow for FlutterFragmentActivity (Works with local_auth)

### DIFF
--- a/android/src/main/kotlin/com/fsconceicao/azure_ad_authentication/AzureAdAuthenticationPlugin.kt
+++ b/android/src/main/kotlin/com/fsconceicao/azure_ad_authentication/AzureAdAuthenticationPlugin.kt
@@ -1,7 +1,6 @@
 package com.fsconceicao.azure_ad_authentication
 
 import android.util.Log
-import io.flutter.embedding.android.FlutterActivity
 import io.flutter.embedding.engine.plugins.FlutterPlugin
 import io.flutter.embedding.engine.plugins.activity.ActivityAware
 import io.flutter.embedding.engine.plugins.activity.ActivityPluginBinding
@@ -41,7 +40,7 @@ class AzureAdAuthenticationPlugin : FlutterPlugin, ActivityAware {
             return;
         }
         msal.let {
-            it?.setActivity(binding.activity as FlutterActivity);
+            it?.setActivity(binding.activity);
         }
     }
 

--- a/android/src/main/kotlin/com/fsconceicao/azure_ad_authentication/Msal.kt
+++ b/android/src/main/kotlin/com/fsconceicao/azure_ad_authentication/Msal.kt
@@ -11,17 +11,16 @@ import com.microsoft.identity.client.exception.MsalClientException
 import com.microsoft.identity.client.exception.MsalException
 import com.microsoft.identity.client.exception.MsalServiceException
 import com.microsoft.identity.client.exception.MsalUiRequiredException
-import io.flutter.embedding.android.FlutterActivity
 import io.flutter.plugin.common.MethodChannel
 
-class Msal(context: Context, activity: FlutterActivity?) {
+class Msal(context: Context, activity: Activity?) {
     internal val applicationContext = context
-    internal var activity: FlutterActivity? = activity
+    internal var activity: Activity? = activity
 
     lateinit var adAuthentication: IMultipleAccountPublicClientApplication
     lateinit var accountList: List<IAccount>
 
-    fun setActivity(activity: FlutterActivity) {
+    fun setActivity(activity: Activity) {
         this.activity = activity;
     }
 

--- a/android/src/main/kotlin/com/fsconceicao/azure_ad_authentication/MsalHandlerImpl.kt
+++ b/android/src/main/kotlin/com/fsconceicao/azure_ad_authentication/MsalHandlerImpl.kt
@@ -169,7 +169,7 @@ class MsalHandlerImpl(private val msal: Msal) : MethodChannel.MethodCallHandler 
 
         msal.activity.let {
             val builder = AcquireTokenParameters.Builder()
-            builder.startAuthorizationFromActivity(it?.activity)
+            builder.startAuthorizationFromActivity(msal.activity)
                 .withScopes(scopes.toList())
                 .withPrompt(Prompt.LOGIN)
                 .withCallback(msal.getAuthCallback(result))


### PR DESCRIPTION
The current version uses FlutterActivity for Android which is acceptable for most cases. However, the [local_auth](https://pub.dev/packages/local_auth) package for flutter requires the use of a FragmentActivity instead of an Activity. [^1]

I've adjusted the Android code to work with both FlutterActivity and FlutterFragmentActivity. This change allows the local_auth package to be used along side this package.

local_auth works along side this package on iOS without any adjustments. I'm requesting this to be merged to maintain functionality across each platform equally.

[^1]: See [Activity Changes](https://pub.dev/packages/local_auth#activity-changes) detailed under [Android integration](https://pub.dev/packages/local_auth#android-integration) for the Flutter [local_auth](https://pub.dev/packages/local_auth) package