### PR TITLE
Account detection on iOS

### DIFF
--- a/ios/Classes/SwiftAzureAdAuthenticationPlugin.swift
+++ b/ios/Classes/SwiftAzureAdAuthenticationPlugin.swift
@@ -241,7 +241,7 @@ extension SwiftAzureAdAuthenticationPlugin {
         // we first signed in the account.
         guard let accountIdentifier = currentAccountIdentifier else {
             // If we did not find an identifier then throw an error indicating there is no currently signed in account.
-            result(FlutterError(code: "CONFIG_ERROR", message: "Account identifier", details: nil))
+            //result(FlutterError(code: "CONFIG_ERROR", message: "Account identifier", details: nil))
             return nil
         }
         var acc: MSALAccount?


### PR DESCRIPTION


When returning CONFIG_ERROR directly from the currentAccount function, an error is returned that can confuse development when in fact it is not a config error but that there is no account logged in, to solve it we have commented this line leaving the absence of an account detected in the acquireTokenSilent as it was initially.